### PR TITLE
fix(config): use comma instead of semicolon as the default delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This library is built to be used in conjunction with [sphere-node-cli](https://g
 ### Configuration
 The configuration object may contain:
 - `config`: configuration object that may contain the following options
-  - `delimiter`: the delimiter to be used in the csv (_default_: `;`)
+  - `delimiter`: the delimiter to be used in the csv (_default_: `,`)
   - `outputFolder` (_required_): the folder used to store the exported product types and attributes
 - `sphereClientConfig`: see the [sphere-node-sdk docs](http://sphereio.github.io/sphere-node-sdk/) for more information on this
 

--- a/src/product-type-export.js
+++ b/src/product-type-export.js
@@ -145,7 +145,7 @@ export default class ProductTypeImport {
 
   // config: {
   //   outputFolder: ''
-  //   delimiter: ';'
+  //   delimiter: ','
   //   compressOutput: false
   // }
   constructor({ sphereClientConfig, config = {} }) {
@@ -160,7 +160,7 @@ export default class ProductTypeImport {
     }
 
     this.config = {
-      delimiter: config.delimiter || ';',
+      delimiter: config.delimiter || ',',
       compressOutput: config.compressOutput || false,
       outputFolder: config.outputFolder,
     }

--- a/tests/integration/product-type-export.js
+++ b/tests/integration/product-type-export.js
@@ -325,10 +325,10 @@ describe('productType export module', function integrationTest() {
       )
       .then(() => {
         const file = fs.readFileSync(destination, 'utf-8')
-        const attributes = productTypeExport.attributeNames.join(';')
+        const attributes = productTypeExport.attributeNames.join(',')
         file.split('\n').forEach((row, i) => {
           if (i === 0) {
-            expect(row).to.equal(`name;description;${attributes}`)
+            expect(row).to.equal(`name,description,${attributes}`)
           }
           // only testing the header row, the rest can be unit tested
         })
@@ -354,9 +354,9 @@ describe('productType export module', function integrationTest() {
       )
       .then(() => {
         const file = fs.readFileSync(destination, 'utf-8').split('\n')
-        const header = file[0].split(';')
+        const header = file[0].split(',')
         const getColIndex = (key) => header.indexOf(key)
-        const getRow = (index) => file[index].split(';')
+        const getRow = (index) => file[index].split(',')
         // check if all the product types have been exported
         productTypeExport.attributeNames.reduce((rowIndex, attrName) => {
           const attrDef = mockAttributes.find(mock => mock.name === attrName)

--- a/tests/unit/product-type-export.js
+++ b/tests/unit/product-type-export.js
@@ -64,4 +64,10 @@ describe('product-type import module', () => {
     const createExporter = () => new ProductTypeExport(noConfigOptions)
     expect(createExporter).to.throw()
   })
+
+  it('should use a comma as default delimiter', () => {
+    const exporter = new ProductTypeExport(options)
+
+    expect(exporter.config.delimiter).to.equal(',')
+  })
 })


### PR DESCRIPTION
To maintain consistency and use the same delimiter as the product-type-import module use a comma
instead of a semicolon to seperate the cells by default. This is also the default delimiter for the
CSV format.

Solves #1