### PR TITLE
fix(export): Fix export of more than 9 enum values

### DIFF
--- a/src/product-type-export.js
+++ b/src/product-type-export.js
@@ -85,7 +85,7 @@ const getValueForKey = (obj, key) => {
 const numberOfRowsForHeaders = headers =>
   headers.filter(h => h.match(/type.values/))
     .reduce((highest, val) => {
-      const regex = /type.values.([0-9])/
+      const regex = /type.values.([0-9]+)/
       const number = parseInt(regex.exec(val)[1], 10)
       return number > highest ? number : highest
     }, 0) + 1

--- a/tests/integration/product-type-export.spec.js
+++ b/tests/integration/product-type-export.spec.js
@@ -81,6 +81,36 @@ const createProductType = () => ({
         }, {
           key: 'polar',
           label: 'Polar',
+        }, {
+          key: 'panda',
+          label: 'Panda',
+        }, {
+          key: 'black',
+          label: 'Black',
+        }, {
+          key: 'sloth',
+          label: 'Sloth',
+        }, {
+          key: 'spectacled',
+          label: 'Spectacled',
+        }, {
+          key: 'asian',
+          label: 'Asian',
+        }, {
+          key: 'ursinae',
+          label: 'ursinae',
+        }, {
+          key: 'short-faced',
+          label: 'Short-faced',
+        }, {
+          key: 'kodiak',
+          label: 'Kodiak',
+        }, {
+          key: 'syrian',
+          label: 'Syrian',
+        }, {
+          key: 'himalayan',
+          label: 'Himalayan',
         }],
       },
       attributeConstraint: 'None',
@@ -311,6 +341,26 @@ test(`productType export module
         'type.values.0.label',
         'type.values.1.key',
         'type.values.1.label',
+        'type.values.2.key',
+        'type.values.2.label',
+        'type.values.3.key',
+        'type.values.3.label',
+        'type.values.4.key',
+        'type.values.4.label',
+        'type.values.5.key',
+        'type.values.5.label',
+        'type.values.6.key',
+        'type.values.6.label',
+        'type.values.7.key',
+        'type.values.7.label',
+        'type.values.8.key',
+        'type.values.8.label',
+        'type.values.9.key',
+        'type.values.9.label',
+        'type.values.10.key',
+        'type.values.10.label',
+        'type.values.11.key',
+        'type.values.11.label',
         'attributeConstraint',
         'isSearchable',
         'inputHint',


### PR DESCRIPTION
#### Summary
This change fixes an export problem when working with more than 9 enum/lenum values.

#### Description
When exporting enum/lenum it exported only maximum of 9 values.

#### TODO

- Tests
    - [ ] Unit
    - [x] Integration
    - [ ] Acceptance
- [ ] Documentation

