### PR TITLE
fix(package): add missing underscore-mixins dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
     "sphere-node-utils": "^0.8.1",
     "tape": "^4.6.0",
     "temp-write": "^2.1.0",
-    "tempfile": "^1.1.1"
+    "tempfile": "^1.1.1",
+    "underscore-mixins": "^0.1.4"
   },
   "nyc": {
     "include": [


### PR DESCRIPTION
Add missing dependency, this is needed to be compatible with npm 3.