### PR TITLE
chore(travis-CI): add node v8 to CI and remove v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ branches:
 notifications:
   email: false
 node_js:
-- '4'
 - '6'
+- '8'
 before_script:
 - npm prune
 script:

--- a/tests/integration/product-type-export-encoding.spec.js
+++ b/tests/integration/product-type-export-encoding.spec.js
@@ -62,7 +62,7 @@ async function before () {
 test(`productType export module
   should output a product types and an attributes `
   + `file using a ${ENCODING} encoding`, async (t) => {
-  t.timeoutAfter(15000) // 15s
+  t.timeoutAfter(30000) // 30s
   const expectedFileName1 = 'attributes.csv'
   const expectedFileName2 = 'products-to-attributes.csv'
   /* eslint-disable max-len */
@@ -72,9 +72,14 @@ test(`productType export module
   const expectedResult2 = 'name,key,description,breite\n'
     + 'custom-product-type,productTypeKey,Some description - žluťoučký kůň úpěl ďábelské ódy,X\n'
 
-  const expectedEncoded1 =
+  let expectedEncoded1 =
     'name,type,attributeConstraint,isRequired,isSearchable,label.en,label.de,textInputHint,displayGroup\n'
     + 'breite,number,None,false,false,EN:�lu�ou�k� k�� �p�l ��belsk� �dy,DE:�=�������=����������,SingleLine,Other\n'
+
+  if (process.version[1] >= 8)
+    expectedEncoded1 = 'name,type,attributeConstraint,isRequired,isSearchable,label.en,label.de,textInputHint,displayGroup\n'
+    + 'breite,number,None,false,false,EN:�lu�ou�k� k�� �p�l ��belsk� �dy,DE:�=������=��������,SingleLine,Other\n'
+
   const expectedEncoded2 = 'name,key,description,breite\n'
     + 'custom-product-type,productTypeKey,Some description - �lu�ou�k� k�� �p�l ��belsk� �dy,X\n'
   /* eslint-enable max-len */

--- a/tests/integration/product-type-export-encoding.spec.js
+++ b/tests/integration/product-type-export-encoding.spec.js
@@ -72,6 +72,12 @@ test(`productType export module
   const expectedResult2 = 'name,key,description,breite\n'
     + 'custom-product-type,productTypeKey,Some description - žluťoučký kůň úpěl ďábelské ódy,X\n'
 
+    /*
+    * TODO
+    * use only one string when Node 10 LTS support kicks in October 2018
+    * remove support for Node v6
+    * remove the if(process.version[1])
+    */
   let expectedEncoded1 =
     'name,type,attributeConstraint,isRequired,isSearchable,label.en,label.de,textInputHint,displayGroup\n'
     + 'breite,number,None,false,false,EN:�lu�ou�k� k�� �p�l ��belsk� �dy,DE:�=�������=����������,SingleLine,Other\n'


### PR DESCRIPTION
#### Summary
Update CI node versions and fix tests errors

#### Description
Add of node v8 to CI and remove v4 in sphere-product-type-export


- add of node v6 and v8 to CI and removal of v4 in sphere-product-type-export

- remove of Attributes error from tests in node v8 above 

- increase of timeout

Part of [this issue](https://github.com/commercetools/nodejs-tasks-board/issues/10)
