### PR TITLE
chore: add keyword for automation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sphere-product-type-export",
   "version": "0.8.1",
-  "description": "",
+  "description": "Exports product types from the commercetools platform.",
   "main": "dist/index.js",
   "bin": {
     "product-type-export": "./bin/product-type-export"
@@ -28,7 +28,8 @@
     "ctp",
     "commercetools",
     "product-type",
-    "export"
+    "export",
+    "cli"
   ],
   "files": [
     "dist",


### PR DESCRIPTION
#### Summary
<!-- Provide a short summary of your changes -->
Adds the cli keyword to packages used by IMPEX to enable automation of the "CLI Overview" page on the docs site. See DOCS-44 for more information.

It also fixes a few grammar issues in the descriptions, since those are getting pulled in too ;)

(cc: @daern91, @Babanila)

#### Description
<!-- Describe the changes in this PR here and provide some context -->

#### TODO

- Tests
    - [ ] Unit
    - [ ] Integration
    - [ ] Acceptance
- [ ] Documentation
